### PR TITLE
Refactor: BloodSugarScreen과 MealScreen에 Flatlist 도입 및 hooks 분리

### DIFF
--- a/frontend/src/hooks/useSafeDate.tsx
+++ b/frontend/src/hooks/useSafeDate.tsx
@@ -1,0 +1,27 @@
+import { useState } from 'react';
+
+export default function useSafeDate() {
+  const [startDate, setStartDate] = useState(new Date());
+  const [endDate, setEndDate] = useState(new Date());
+
+  const setStartDateSafe = (date: Date) => {
+    if (date > endDate) {
+      setStartDate(endDate);
+    } else {
+      setStartDate(date);
+    }
+  };
+
+  const setEndDateSafe = (date: Date) => {
+    const now = new Date();
+    if (date > now) {
+      setEndDate(now);
+    } else if (date < startDate) {
+      setEndDate(startDate);
+    } else {
+      setEndDate(date);
+    }
+  };
+
+  return { startDate, endDate, setStartDateSafe, setEndDateSafe };
+}

--- a/frontend/src/hooks/useScroll.tsx
+++ b/frontend/src/hooks/useScroll.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import { NativeSyntheticEvent, NativeScrollEvent } from 'react-native';
+
+export default function useScroll() {
+  const [isTop, setIsTop] = useState(true);
+
+  const handleScroll = (
+    event: NativeSyntheticEvent<NativeScrollEvent>,
+    isEnd: boolean,
+    setPage: React.Dispatch<React.SetStateAction<number>>
+  ) => {
+    const { nativeEvent } = event;
+    const { contentOffset, layoutMeasurement, contentSize } = nativeEvent;
+    const isScrolledToTop = contentOffset.y === 0;
+    const isScrolledToBottom =
+      Math.round(contentOffset.y + layoutMeasurement.height) >=
+      Math.round(contentSize.height);
+    setIsTop(isScrolledToTop);
+    if (isScrolledToBottom && !isEnd) {
+      setPage((prevPage) => prevPage + 1);
+    }
+  };
+
+  return { isTop, handleScroll };
+}


### PR DESCRIPTION
### Part

- [x] FE
- [ ] BE
- [ ] etc.
      <br>

### Changes

    - Refactor: BloodSugarScreen과 MealScreen에서 중복되는 handleScroll, setStartDateSafe, setEndDateSafe를 분리하였습니다.
    - Fix: ScrollView는 한번에 모든 데이터를 렌더링해 성능이 떨어지는 단점이 있었습니다(참조 : https://reactnative.dev/docs/scrollview)
    - 해결을 위해 화면에 보이는 데이터만을 렌더링하는 Flatlist를 BloodSugarScreen과 MealScreen에 도입하였습니다.
    - 논의사항: 없음

<br>

### Test Checklist ☑️

- [x] 로직에 눈에 띄는 문제점이 있는지
      <br>

### Screenshot(option)

<br>